### PR TITLE
Replace paused with entity_status

### DIFF
--- a/lib/twitter-ads/campaign/campaign.rb
+++ b/lib/twitter-ads/campaign/campaign.rb
@@ -23,7 +23,7 @@ module TwitterAds
     property :funding_instrument_id
     property :end_time, type: :time
     property :start_time, type: :time
-    property :paused, type: :bool
+    property :entity_status
     property :currency
     property :standard_delivery
     property :daily_budget_amount_local_micro

--- a/lib/twitter-ads/campaign/line_item.rb
+++ b/lib/twitter-ads/campaign/line_item.rb
@@ -25,7 +25,7 @@ module TwitterAds
     property :include_sentiment
     property :objective
     property :optimization
-    property :paused, type: :bool
+    property :entity_status
     property :primary_web_event_tag
     property :product_type
     property :placements


### PR DESCRIPTION
Paused property has been abolished in Twitter Ads API v2. 
Tests will be written later.